### PR TITLE
use both header and a query string parameter for the x-token-auth

### DIFF
--- a/lib/multi-auth.lua
+++ b/lib/multi-auth.lua
@@ -8,7 +8,7 @@ local whitelist_ips = multiauth_ip_whitelist or {}
 
 whitelist = iputils.parse_cidrs(whitelist_ips)
 
-local token_auth = ngx.var.http_x_token_auth and ngx.var_http_x_token_auth or ngx.var.arg_x_token_auth
+local token_auth = ngx.var.http_x_token_auth or ngx.var.arg_x_token_auth
 
 if iputils.ip_in_cidrs(ngx.var.remote_addr, whitelist) then
   ngx.log(ngx.ERR, "Requestor " .. ngx.var.remote_addr .. " on whitelist")

--- a/lib/multi-auth.lua
+++ b/lib/multi-auth.lua
@@ -8,14 +8,13 @@ local whitelist_ips = multiauth_ip_whitelist or {}
 
 whitelist = iputils.parse_cidrs(whitelist_ips)
 
-local header_token_auth = ngx.var.http_x_token_auth
-local query_string_token_auth = ngx.var.arg_x_token_auth
+local token_auth = ngx.var.http_x_token_auth and ngx.var_http_x_token_auth or ngx.var.arg_x_token_auth
 
 if iputils.ip_in_cidrs(ngx.var.remote_addr, whitelist) then
   ngx.log(ngx.ERR, "Requestor " .. ngx.var.remote_addr .. " on whitelist")
-elseif header_token_auth or query_string_token_auth then
+elseif token_auth then
   ngx.log(ngx.ERR, "Checking auth header...")
-  token_access.check_token(token_auth, query_string_token_auth)
+  token_access.check_token(token_auth)
 else
   ngx.log(ngx.ERR, "Validating oauth...")
   oauth_access.validate()

--- a/lib/multi-auth.lua
+++ b/lib/multi-auth.lua
@@ -8,13 +8,14 @@ local whitelist_ips = multiauth_ip_whitelist or {}
 
 whitelist = iputils.parse_cidrs(whitelist_ips)
 
-local token_auth = ngx.var.http_x_token_auth
+local header_token_auth = ngx.var.http_x_token_auth
+local query_string_token_auth = ngx.var.arg_x_token_auth
 
 if iputils.ip_in_cidrs(ngx.var.remote_addr, whitelist) then
   ngx.log(ngx.ERR, "Requestor " .. ngx.var.remote_addr .. " on whitelist")
-elseif token_auth then
+elseif header_token_auth or query_string_token_auth then
   ngx.log(ngx.ERR, "Checking auth header...")
-  token_access.check_token(token_auth)
+  token_access.check_token(token_auth, query_string_token_auth)
 else
   ngx.log(ngx.ERR, "Validating oauth...")
   oauth_access.validate()

--- a/lib/token-access.lua
+++ b/lib/token-access.lua
@@ -2,10 +2,7 @@ local _M = {}
 
 local authorized_tokens = multiauth_authorized_tokens or {}
 
-local function check_token(raw_token)
-
-    local token = string.sub(raw_token, 7)
-    ngx.log(ngx.ERR, "cleaned token is " .. token)
+local function check_token(token)
 
     if not authorized_tokens[token] then
         ngx.header.content_type = "text/html"

--- a/lib/token-access.lua
+++ b/lib/token-access.lua
@@ -2,12 +2,9 @@ local _M = {}
 
 local authorized_tokens = multiauth_authorized_tokens or {}
 
-local function check_token(raw_token)
+local function check_token(header_token, qs_token)
 
-    local token = string.sub(raw_token, 7)
-    ngx.log(ngx.ERR, "cleaned token is " .. token)
-
-    if not authorized_tokens[token] then
+    if not authorized_tokens[header_token] and not authorized_token[qs_token] then
         ngx.header.content_type = "text/html"
         ngx.status = ngx.HTTP_UNAUTHORIZED
         ngx.say("<h1>401 Unauthorized</h1>")

--- a/lib/token-access.lua
+++ b/lib/token-access.lua
@@ -2,9 +2,12 @@ local _M = {}
 
 local authorized_tokens = multiauth_authorized_tokens or {}
 
-local function check_token(header_token, qs_token)
+local function check_token(raw_token)
 
-    if not authorized_tokens[header_token] and not authorized_token[qs_token] then
+    local token = string.sub(raw_token, 7)
+    ngx.log(ngx.ERR, "cleaned token is " .. token)
+
+    if not authorized_tokens[token] then
         ngx.header.content_type = "text/html"
         ngx.status = ngx.HTTP_UNAUTHORIZED
         ngx.say("<h1>401 Unauthorized</h1>")


### PR DESCRIPTION
addresses https://refinery29.atlassian.net/browse/HD-2953

- checks query string parameter in addition to the header
- use either value
- use the value as is, no need chop the first 7 characters